### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add contents: write permission to allow GITHUB_TOKEN to create releases on tag pushes.